### PR TITLE
Improve link color contrast for accessibility

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -16,7 +16,7 @@ $spacing-unit:     30px;
 
 $text-color:       #111;
 $background-color: #fdfdfd;
-$brand-color:      #2a7ae2;
+$brand-color:      #0645ad;
 
 $grey-color:       #828282;
 $grey-color-light: lighten($grey-color, 40%);


### PR DESCRIPTION
Update `$brand-color` to a darker blue to meet accessibility contrast requirements for links.

---
<a href="https://cursor.com/background-agent?bcId=bc-1888f6ed-b78e-4d2f-bb26-a6a1eafc8307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1888f6ed-b78e-4d2f-bb26-a6a1eafc8307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

